### PR TITLE
Update openai_python_script.py

### DIFF
--- a/openai_python_script.py
+++ b/openai_python_script.py
@@ -1,4 +1,4 @@
-import openai
+from openai import OpenAI
 import sys
 
 client = OpenAI(


### PR DESCRIPTION
Changed the import to work again since OpenAI changed their API.
Right in the OpenAI GitHub repo it is stated that the import line needs to be "from openai import OpenAI", found this while trying to use this makro and getting an error message.